### PR TITLE
Add --platform to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG IMAGE
-FROM $IMAGE
+FROM --platform=linux/amd64 ${IMAGE}
 
 WORKDIR /project
 

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,5 +1,4 @@
-ARG PLATFORM=linux/amd64
-FROM --platform=${PLATFORM} node:22-bookworm-slim
+FROM --platform=linux/amd64 node:22-bookworm-slim
 
 RUN apt-get -yq update &&\
   apt-get -yqq install --no-install-recommends ca-certificates curl tar &&\

--- a/README.md
+++ b/README.md
@@ -36,21 +36,9 @@ For example:
 The verifier and deployer need `docker` installed and running.
 The developer does not necessarily need `docker`.
 
-#### On Mac
-
-On Mac, `colima` is required which can be installed from https://github.com/abiosoft/colima.
-It is important to start colima with the command:
-
-```
-colima start --arch x86_64
-```
-
-If colima had been started before without the `--arch` option then we must run
-
-```
-colima delete
-```
-first before starting it again.
+On Mac, it is recommended to install `colima` from https://github.com/abiosoft/colima.
+When using `colima` it is ok to use value `host` in the `--arch`.
+This is also the default so the `--arch` option can be omitted.
 
 ### dfx
 


### PR DESCRIPTION
Fix the README section about colima --arch option. Host arch (default) is ok now.